### PR TITLE
Puppet URIs must have 3 slashes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,7 +130,7 @@ class utf_8 (
       if $ensure_static_files {
         file { "${dir0}${file_name}":
           ensure => file,
-          source => 'puppet://modules/utf_8/静的',
+          source => 'puppet:///modules/utf_8/静的',
         }
       }
 


### PR DESCRIPTION
Puppet will not parse URIs in an expected manner if the URI is not specified properly.

Documentation is available at https://docs.puppet.com/puppet/4.8/file_serving.html#whats-a-mount-point-in-a-puppet-uri